### PR TITLE
0006 : Reload page when I modify the column highlight spaces order

### DIFF
--- a/portlets/src/main/frontend/apps/functionalConfiguration/components/functionalConfiguration.vue
+++ b/portlets/src/main/frontend/apps/functionalConfiguration/components/functionalConfiguration.vue
@@ -232,12 +232,16 @@ export default {
           .then(data => {
 
             space.activityComposerVisible = data.activityComposerVisible;
+            var needReload = !(space.highlightConfiguration.highlight==data.highlightConfiguration.highlight && space.highlightConfiguration.order==data.highlightConfiguration.order);
             space.highlightConfiguration = data.highlightConfiguration;
         
             self.cancelEdit(space);
             delete self.currentSpaceSaved;
 
-              this.successResponse();
+            this.successResponse();
+            if (needReload) {
+                location.reload();
+            }
           })
             .catch(error => {
                 this.failedResponse();


### PR DESCRIPTION
This commit add a reload in the case administrator changes the hightlighted spaces order

Fix #11 